### PR TITLE
Change cursor when hovering over table header or relation

### DIFF
--- a/src/pods/canvas/components/relation/components/clickable-line.component.tsx
+++ b/src/pods/canvas/components/relation/components/clickable-line.component.tsx
@@ -26,6 +26,7 @@ export const ClickableLineComponent: React.FC<Props> = props => {
       stroke="transparent"
       onClick={handleClick}
       onDoubleClick={() => onDoubleClick(id)}
+      style={{ cursor: 'pointer' }}
     />
   );
 };

--- a/src/pods/canvas/components/table/database-table.module.css
+++ b/src/pods/canvas/components/table/database-table.module.css
@@ -2,6 +2,10 @@
   user-select: none;
 }
 
+.table-container:hover {
+  cursor: grabbing;
+}
+
 .tableText {
   font-family: 'Arial', sans-serif;
   font-size: 14px;


### PR DESCRIPTION
For the line I had to add the direct style, I added the hover in the .selected-relation classes, but it didn't work as I expected.