### PR TITLE
Remove Mongo Shcema option in Export

### DIFF
--- a/src/pods/export/export-table.pod.tsx
+++ b/src/pods/export/export-table.pod.tsx
@@ -50,19 +50,6 @@ export const ExportTablePod: React.FC<Props> = props => {
             <span className={classes.radioButtonCustom}></span>PNG
           </label>
         </div>
-        <div className={classes.radioButton}>
-          <input
-            className={classes.radioButtonInput}
-            type="radio"
-            name="export type"
-            id="radio3"
-            aria-label="Mongo Schema"
-            onChange={() => handleExportType('mongo')}
-          />
-          <label htmlFor="radio3" className={classes.radioButtonLabel}>
-            <span className={classes.radioButtonCustom}></span>Mongo Schema
-          </label>
-        </div>
       </div>
       <button className="button-secondary" onClick={handleExportClick}>
         Export


### PR DESCRIPTION
Closed #209

@brauliodiez 

I saw two "residual elements" 
The first one is in the Readme, says on line 16: `- Allows exporting to SVG, PNG, and Mongo Schema formats.`
The second one is in "core/model/index.ts" on line 25: `export type ExportType = 'svg' | 'png' | 'mongo';`,  the mongo type was only used there.