### PR TITLE
#210 - Export Mongo Schema option

### DIFF
--- a/src/common/export/download-svg.business.ts
+++ b/src/common/export/download-svg.business.ts
@@ -27,3 +27,7 @@ export const downloadImage = (svg: JSX.Element, viewBoxSize: Size) => {
     }
   };
 };
+
+export const downloadSchemaScript = (schemaScript: string) => {
+  downloadFile('schemaScript.js', schemaScript, 'text/javascript');
+};

--- a/src/core/model/index.ts
+++ b/src/core/model/index.ts
@@ -22,7 +22,12 @@ export type FieldType =
   | 'timestamp'
   | 'undefined';
 
-export type ExportType = 'svg' | 'png' | 'mongo';
+export enum ExportType {
+  SVG = 'svg',
+  PNG = 'png',
+  MONGO = 'mongo',
+  SCHEMA = 'schema',
+}
 
 export interface Size {
   width: number;

--- a/src/pods/export/export-table.pod.tsx
+++ b/src/pods/export/export-table.pod.tsx
@@ -14,11 +14,11 @@ export const ExportTablePod: React.FC<Props> = props => {
     React.useState<ExportType | null>(null);
 
   const handleExportType = (exportType: ExportType) => {
-    setSelectedExportType(exportType ?? 'svg');
+    setSelectedExportType(exportType ?? ExportType.SVG);
   };
 
   const handleExportClick = () => {
-    onExport(selectedExportType ?? 'svg');
+    onExport(selectedExportType ?? ExportType.SVG);
     closeModal();
   };
   return (
@@ -31,7 +31,7 @@ export const ExportTablePod: React.FC<Props> = props => {
             name="export type"
             id="radio2"
             aria-label="SVG"
-            onChange={() => handleExportType('svg')}
+            onChange={() => handleExportType(ExportType.SVG)}
           />
           <label htmlFor="radio2" className={classes.radioButtonLabel}>
             <span className={classes.radioButtonCustom}></span>SVG
@@ -44,10 +44,23 @@ export const ExportTablePod: React.FC<Props> = props => {
             name="export type"
             id="radio1"
             aria-label="PNG"
-            onChange={() => handleExportType('png')}
+            onChange={() => handleExportType(ExportType.PNG)}
           />
           <label htmlFor="radio1" className={classes.radioButtonLabel}>
             <span className={classes.radioButtonCustom}></span>PNG
+          </label>
+        </div>
+        <div className={classes.radioButton}>
+          <input
+            className={classes.radioButtonInput}
+            type="radio"
+            name="export type"
+            id="radio3"
+            aria-label="Mongo Schema"
+            onChange={() => handleExportType(ExportType.SCHEMA)}
+          />
+          <label htmlFor="radio3" className={classes.radioButtonLabel}>
+            <span className={classes.radioButtonCustom}></span>Mongo Schema
           </label>
         </div>
       </div>

--- a/src/pods/toolbar/components/export-button/export-button.component.tsx
+++ b/src/pods/toolbar/components/export-button/export-button.component.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { EDIT_COLLECTION_TITLE, ExportIcon } from '@/common/components';
-import { downloadImage, downloadSvg } from '@/common/export';
+import {
+  downloadImage,
+  downloadSchemaScript,
+  downloadSvg,
+} from '@/common/export';
 import { ExportType, Size } from '@/core/model';
 import {
   useModalDialogContext,
@@ -11,9 +15,10 @@ import {
 } from '@/core/providers';
 import { ExportTablePod, CanvasExportSvgComponent } from '@/pods/export';
 import {
+  expandAllFieldsInTables,
   getMaxPositionYFromTables,
   getMaxPositionXFromTables,
-  expandAllFieldsInTables,
+  getSchemaScriptFromTableVmArray,
 } from './export-button.business';
 import { ToolbarButton } from '../toolbar-button/toolbarButton.component';
 import classes from '@/pods/toolbar/toolbar.pod.module.css';
@@ -71,13 +76,24 @@ export const ExportButton = () => {
     downloadImage(svg, downloadCanvasSize);
   };
 
+  const exportSchema = () => {
+    const schemaScript = getSchemaScriptFromTableVmArray(
+      tablesWithExpandedFields
+    );
+
+    downloadSchemaScript(schemaScript);
+  };
+
   const handleExportToFormat = (exportType: ExportType) => {
     switch (exportType) {
-      case 'svg':
+      case ExportType.SVG:
         exportSvg();
         break;
-      case 'png':
+      case ExportType.PNG:
         exportImage();
+        break;
+      case ExportType.SCHEMA:
+        exportSchema();
         break;
       default:
         break;


### PR DESCRIPTION
Closes #210 

Some comments here:

- Exported file name is `schemaScript.js`, but it can be modified.
- I converted `ExportType` from `type` to `enum`. I consider it is better to use any of the options of the enum than plain strings. If we would like to change an option (for instance, from `png` to `jpg`), the hypothetical change would take place only in the enum.
- Mongo Schemas have a field named `isRequired` (https://www.mongodb.com/docs/atlas/app-services/schemas/#define-a-schema), but we cannot fill it yet till NN feature is implemented. When implemented, I would add a field named `isRequired` in `FieldVm` interface.

If you have any other question/suggestion, please let me know