### PR TITLE
Commented out CanvasSettingButton in ToolbarPod

### DIFF
--- a/src/pods/toolbar/toolbar.pod.tsx
+++ b/src/pods/toolbar/toolbar.pod.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  CanvasSettingButton,
+  // CanvasSettingButton,
   ZoomInButton,
   ZoomOutButton,
   RelationButton,
@@ -31,7 +31,8 @@ export const ToolbarPod: React.FC = () => {
       <RedoButton />
       <ExportButton />
       <DeleteButton />
-      <CanvasSettingButton />
+      {/* At the moment there are no settings to display. When autosave is implemented, uncomment CanvasSettingButton */}
+      {/* <CanvasSettingButton /> */}
       <AboutButton />
       <ThemeToggleButton darkLabel="Dark Mode" lightLabel="Light Mode" />
     </div>


### PR DESCRIPTION
Now the application does not need a configuration button. Leaving this button deactivated is perhaps strange for the user because he never has access to it.

Closed #382 