### PR TITLE
[READY_TO_REVIEW]Make edit-table elements accessible

### DIFF
--- a/src/common/components/checkbox/checkbox.component.tsx
+++ b/src/common/components/checkbox/checkbox.component.tsx
@@ -6,10 +6,11 @@ interface Props {
   onChange: () => void;
   disabled?: boolean;
   ariaLabelledby?: string;
+  ariaLabel?: string;
 }
 
 export const Checkbox: React.FC<Props> = props => {
-  const { id, onChange, disabled, checked, ariaLabelledby } = props;
+  const { id, onChange, disabled, checked, ariaLabelledby, ariaLabel } = props;
 
   return (
     <div className={`${classes.checkbox} ${disabled && classes.disabled}`}>
@@ -20,8 +21,9 @@ export const Checkbox: React.FC<Props> = props => {
         onChange={onChange}
         disabled={disabled}
         aria-labelledby={ariaLabelledby}
+        aria-label={ariaLabel}
       />
-      <div>
+      <div aria-hidden="true">
         <svg viewBox="0,0,50,50">
           <path d="M5 30 L 20 45 L 45 8"></path>
         </svg>

--- a/src/common/components/icons/expand-down-icon.component.tsx
+++ b/src/common/components/icons/expand-down-icon.component.tsx
@@ -6,6 +6,7 @@ export const ExpandDown = () => {
       height="1.2em"
       viewBox="0 0 256 256"
       aria-labelledby="expand-down"
+      aria-label="expand field"
     >
       <title id="expand-down">Desplegar opciones</title>
       <path

--- a/src/common/components/icons/expand-down-icon.component.tsx
+++ b/src/common/components/icons/expand-down-icon.component.tsx
@@ -5,10 +5,8 @@ export const ExpandDown = () => {
       width="1.2em"
       height="1.2em"
       viewBox="0 0 256 256"
-      aria-labelledby="expand-down"
-      aria-label="expand field"
+      aria-hidden="true"
     >
-      <title id="expand-down">Desplegar opciones</title>
       <path
         fill="currentColor"
         d="m212.24 100.24l-80 80a6 6 0 0 1-8.48 0l-80-80a6 6 0 0 1 8.48-8.48L128 167.51l75.76-75.75a6 6 0 0 1 8.48 8.48"

--- a/src/common/components/icons/right-arrow.component.tsx
+++ b/src/common/components/icons/right-arrow.component.tsx
@@ -5,6 +5,7 @@ export const RightArrowIcon = () => {
       width="1em"
       height="1em"
       viewBox="0 0 256 256"
+      aria-label="contract field"
     >
       <path
         fill="currentColor"

--- a/src/common/components/icons/right-arrow.component.tsx
+++ b/src/common/components/icons/right-arrow.component.tsx
@@ -5,7 +5,7 @@ export const RightArrowIcon = () => {
       width="1em"
       height="1em"
       viewBox="0 0 256 256"
-      aria-label="contract field"
+      aria-hidden="true"
     >
       <path
         fill="currentColor"

--- a/src/pods/edit-table/components/commands/command-icon-button.tsx
+++ b/src/pods/edit-table/components/commands/command-icon-button.tsx
@@ -2,13 +2,14 @@ interface Props {
   onClick: () => void;
   icon: JSX.Element;
   disabled?: boolean;
+  ariaLabel?: string;
 }
 
 export const CommandIconButton: React.FC<Props> = props => {
-  const { onClick, icon, disabled } = props;
+  const { onClick, icon, disabled, ariaLabel } = props;
 
   return (
-    <button onClick={onClick} disabled={disabled}>
+    <button onClick={onClick} disabled={disabled} aria-label={ariaLabel}>
       {icon}
     </button>
   );

--- a/src/pods/edit-table/components/commands/commands.component.tsx
+++ b/src/pods/edit-table/components/commands/commands.component.tsx
@@ -15,6 +15,12 @@ interface Props {
   isDeleteVisible: boolean;
 }
 
+const ADD_FOLDER = 'Add nested field';
+const REMOVE_ICON = 'Remove';
+const ADD = 'Add field';
+const UP_ICON = 'Up field';
+const DOWN_ICON = 'Down field';
+
 export const Commands: React.FC<Props> = (props: Props) => {
   const {
     field,
@@ -31,28 +37,33 @@ export const Commands: React.FC<Props> = (props: Props) => {
       <CommandIconButton
         icon={<Add />}
         onClick={() => onAddField(field.id, false, GenerateGUID())}
+        ariaLabel={ADD}
       />
       {field.type === 'object' && (
         <CommandIconButton
           icon={<AddFolder />}
           onClick={() => onAddField(field.id, true, GenerateGUID())}
+          ariaLabel={ADD_FOLDER}
         />
       )}
       {isDeleteVisible && (
         <CommandIconButton
           icon={<RemoveIcon />}
           onClick={() => onDeleteField(field.id)}
+          ariaLabel={REMOVE_ICON + field.id}
         />
       )}
       <CommandIconButton
         icon={<UpIcon />}
         onClick={() => onMoveUpField(field.id)}
         disabled={isFirstItemInArray(fields, field.id)}
+        ariaLabel={UP_ICON + field.id}
       />
       <CommandIconButton
         icon={<DownIcon />}
         onClick={() => onMoveDownField(field.id)}
         disabled={isLastItemInArray(fields, field.id)}
+        ariaLabel={DOWN_ICON + field.id}
       />
     </>
   );

--- a/src/pods/edit-table/components/commands/commands.component.tsx
+++ b/src/pods/edit-table/components/commands/commands.component.tsx
@@ -13,9 +13,10 @@ interface Props {
   onMoveDownField: (fieldId: GUID) => void;
   onMoveUpField: (fieldId: GUID) => void;
   isDeleteVisible: boolean;
+  labelAddField?: string;
 }
 
-const ADD_FOLDER = 'Add nested field';
+const ADD_FOLDER = 'Add nested field for ';
 const REMOVE_ICON = 'Remove';
 const ADD = 'Add field';
 const UP_ICON = 'Up field';
@@ -30,6 +31,7 @@ export const Commands: React.FC<Props> = (props: Props) => {
     onMoveDownField,
     onMoveUpField,
     isDeleteVisible,
+    labelAddField,
   } = props;
 
   return (
@@ -37,33 +39,33 @@ export const Commands: React.FC<Props> = (props: Props) => {
       <CommandIconButton
         icon={<Add />}
         onClick={() => onAddField(field.id, false, GenerateGUID())}
-        ariaLabel={ADD}
+        ariaLabel={labelAddField || ADD}
       />
       {field.type === 'object' && (
         <CommandIconButton
           icon={<AddFolder />}
           onClick={() => onAddField(field.id, true, GenerateGUID())}
-          ariaLabel={ADD_FOLDER}
+          ariaLabel={ADD_FOLDER + field.name}
         />
       )}
       {isDeleteVisible && (
         <CommandIconButton
           icon={<RemoveIcon />}
           onClick={() => onDeleteField(field.id)}
-          ariaLabel={REMOVE_ICON + field.id}
+          ariaLabel={REMOVE_ICON + field.name}
         />
       )}
       <CommandIconButton
         icon={<UpIcon />}
         onClick={() => onMoveUpField(field.id)}
         disabled={isFirstItemInArray(fields, field.id)}
-        ariaLabel={UP_ICON + field.id}
+        ariaLabel={UP_ICON + field.name}
       />
       <CommandIconButton
         icon={<DownIcon />}
         onClick={() => onMoveDownField(field.id)}
         disabled={isLastItemInArray(fields, field.id)}
-        ariaLabel={DOWN_ICON + field.id}
+        ariaLabel={DOWN_ICON + field.name}
       />
     </>
   );

--- a/src/pods/edit-table/components/field.tsx
+++ b/src/pods/edit-table/components/field.tsx
@@ -32,6 +32,7 @@ interface Props {
   onMoveUpField: (fieldId: GUID) => void;
   onDragField: (fields: FieldVm[], id?: GUID) => void;
   isDeleteVisible: boolean;
+  labelAddField?: string;
 }
 
 const INPUT_NAME = 'Field for field ';
@@ -40,6 +41,7 @@ const CHECKBOX_FK = 'Checkbox fk for field ';
 const CHECKBOX_ARRAY = 'Checkbox isArray for field ';
 const CHECKBOX_ISNN = 'Checkbox isNN for field ';
 const SELECT = 'Select field type for';
+const NESTED_FIELD_ADD_FIELD_LABEL = 'Add nested field for ';
 
 export const Field: React.FC<Props> = props => {
   const {
@@ -57,6 +59,7 @@ export const Field: React.FC<Props> = props => {
     updateFieldValue,
     nameInputRefRecord,
     isDeleteVisible,
+    labelAddField,
   } = props;
   const variantsItem = {
     left: {
@@ -127,7 +130,14 @@ export const Field: React.FC<Props> = props => {
           </motion.button>
           <div className={`${classes.expandCell} ${classes[`indent${level}`]}`}>
             {field.type === 'object' ? (
-              <button onClick={() => toggleExpand(field.id)}>
+              <button
+                onClick={() => toggleExpand(field.id)}
+                aria-label={
+                  expandedFields.has(field.id)
+                    ? 'contract nested fields'
+                    : 'expand nested fields'
+                }
+              >
                 {expandedFields.has(field.id) ? (
                   <ExpandDown />
                 ) : (
@@ -154,7 +164,7 @@ export const Field: React.FC<Props> = props => {
             id="check1"
             checked={field.PK}
             onChange={() => updateFieldValue(field, 'PK', !field.PK)}
-            ariaLabel={CHECKBOX_PK}
+            ariaLabel={CHECKBOX_PK + field.name}
           ></Checkbox>
         </div>
         <div className={classes.fieldCell}>
@@ -163,7 +173,7 @@ export const Field: React.FC<Props> = props => {
             checked={field.FK}
             onChange={() => updateFieldValue(field, 'FK', !field.FK)}
             disabled={true}
-            ariaLabel={CHECKBOX_FK}
+            ariaLabel={CHECKBOX_FK + field.name}
           ></Checkbox>
         </div>
         <div className={classes.fieldCell}>
@@ -172,7 +182,7 @@ export const Field: React.FC<Props> = props => {
             onChange={e =>
               updateFieldValue(field, 'type', e.target.value as FieldType)
             }
-            aria-labelledby={SELECT + field.id}
+            aria-label={SELECT + field.name}
           >
             {fieldTypeOptions.map(entry => (
               <option key={entry.value} value={entry.value}>
@@ -186,7 +196,7 @@ export const Field: React.FC<Props> = props => {
             id="check3"
             checked={field.isArray || false}
             onChange={() => updateFieldValue(field, 'isArray', !field.isArray)}
-            ariaLabel={CHECKBOX_ARRAY}
+            ariaLabel={CHECKBOX_ARRAY + field.name}
           ></Checkbox>
         </div>
         <div className={classes.fieldCell}>
@@ -194,7 +204,7 @@ export const Field: React.FC<Props> = props => {
             id="check4"
             checked={field.isNN || false}
             onChange={() => updateFieldValue(field, 'isNN', !field.isNN)}
-            ariaLabel={CHECKBOX_ISNN}
+            ariaLabel={CHECKBOX_ISNN + field.name}
           ></Checkbox>
         </div>
         <div className={`${classes.fieldCell} ${classes.commandsContainer}`}>
@@ -206,6 +216,7 @@ export const Field: React.FC<Props> = props => {
             onMoveDownField={onMoveDownField}
             onMoveUpField={onMoveUpField}
             isDeleteVisible={isDeleteVisible}
+            labelAddField={labelAddField}
           />
         </div>
       </Reorder.Item>
@@ -225,6 +236,7 @@ export const Field: React.FC<Props> = props => {
           onDragField={onDragField}
           nameInputRefRecord={nameInputRefRecord}
           isDeleteVisible={isDeleteVisible}
+          labelAddField={NESTED_FIELD_ADD_FIELD_LABEL + field.name}
         />
       )}
     </React.Fragment>

--- a/src/pods/edit-table/components/field.tsx
+++ b/src/pods/edit-table/components/field.tsx
@@ -34,6 +34,13 @@ interface Props {
   isDeleteVisible: boolean;
 }
 
+const INPUT_NAME = 'Field for field ';
+const CHECKBOX_PK = 'Checkbox pk for field ';
+const CHECKBOX_FK = 'Checkbox fk for field ';
+const CHECKBOX_ARRAY = 'Checkbox isArray for field ';
+const CHECKBOX_ISNN = 'Checkbox isNN for field ';
+const SELECT = 'Select field type for';
+
 export const Field: React.FC<Props> = props => {
   const {
     field,
@@ -113,6 +120,8 @@ export const Field: React.FC<Props> = props => {
             className={classes.dragButton}
             onPointerDown={e => handlerPointerDown(e, field)}
             onPointerUp={e => (e.currentTarget.style.cursor = 'grab')}
+            aria-hidden="true"
+            tabIndex={-1}
           >
             <DragDropIcon />
           </motion.button>
@@ -135,6 +144,7 @@ export const Field: React.FC<Props> = props => {
                   updateFieldValue(field, 'name', e.target.value);
                 }}
                 ref={el => assignRef(el, field.id)}
+                aria-label={INPUT_NAME + field.name}
               />
             </div>
           </div>
@@ -144,7 +154,7 @@ export const Field: React.FC<Props> = props => {
             id="check1"
             checked={field.PK}
             onChange={() => updateFieldValue(field, 'PK', !field.PK)}
-            ariaLabelledby="Is PK"
+            ariaLabel={CHECKBOX_PK}
           ></Checkbox>
         </div>
         <div className={classes.fieldCell}>
@@ -153,7 +163,7 @@ export const Field: React.FC<Props> = props => {
             checked={field.FK}
             onChange={() => updateFieldValue(field, 'FK', !field.FK)}
             disabled={true}
-            ariaLabelledby="Is FK"
+            ariaLabel={CHECKBOX_FK}
           ></Checkbox>
         </div>
         <div className={classes.fieldCell}>
@@ -162,6 +172,7 @@ export const Field: React.FC<Props> = props => {
             onChange={e =>
               updateFieldValue(field, 'type', e.target.value as FieldType)
             }
+            aria-labelledby={SELECT + field.id}
           >
             {fieldTypeOptions.map(entry => (
               <option key={entry.value} value={entry.value}>
@@ -175,7 +186,7 @@ export const Field: React.FC<Props> = props => {
             id="check3"
             checked={field.isArray || false}
             onChange={() => updateFieldValue(field, 'isArray', !field.isArray)}
-            ariaLabelledby="Is an Array"
+            ariaLabel={CHECKBOX_ARRAY}
           ></Checkbox>
         </div>
         <div className={classes.fieldCell}>
@@ -183,7 +194,7 @@ export const Field: React.FC<Props> = props => {
             id="check4"
             checked={field.isNN || false}
             onChange={() => updateFieldValue(field, 'isNN', !field.isNN)}
-            ariaLabelledby="Is a NN"
+            ariaLabel={CHECKBOX_ISNN}
           ></Checkbox>
         </div>
         <div className={`${classes.fieldCell} ${classes.commandsContainer}`}>

--- a/src/pods/edit-table/components/nested-field-grid.tsx
+++ b/src/pods/edit-table/components/nested-field-grid.tsx
@@ -25,6 +25,7 @@ interface NestedFieldGridProps {
   onMoveUpField: (fieldId: GUID) => void;
   onDragField: (fields: FieldVm[], id?: GUID) => void;
   isDeleteVisible: boolean;
+  labelAddField?: string;
 }
 
 export const NestedFieldGrid: React.FC<NestedFieldGridProps> = ({
@@ -42,6 +43,7 @@ export const NestedFieldGrid: React.FC<NestedFieldGridProps> = ({
   onMoveUpField,
   onDragField,
   isDeleteVisible,
+  labelAddField,
 }) => {
   const variantsGroup = {
     open: { opacity: 1, height: 'auto' },
@@ -78,6 +80,7 @@ export const NestedFieldGrid: React.FC<NestedFieldGridProps> = ({
             updateFieldValue={updateFieldValue}
             nameInputRefRecord={nameInputRefRecord}
             isDeleteVisible={isDeleteVisible}
+            labelAddField={labelAddField}
           />
         ))}
       </AnimatePresence>


### PR DESCRIPTION
vincular el mensaje con un elemento identificado por su ID, asi se establece una relacion semantica clara entre el mensaje y una etiqueta descriptiva.

He probado el lector de pantalla y no tuve ningún inconveniente, aquí adjunto el video.

https://github.com/Lemoncode/mongo-modeler/assets/112188399/45053a5c-0093-49f1-b854-54dbf747631f

