### PR TITLE
Added devcontainer file to test Mongo Modeler

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:dev-20",
+  "name": "MongoDB Library Sample App - Nodejs version",
+  "updateContentCommand": "", 
+  "postAttachCommand": {
+    "server": "npm install && npm run dev -- --host 0.0.0.0"
+  },
+  "customizations": {
+    "codespaces": {
+      "openFiles": [
+        "src/main.tsx"
+      ]
+    },
+    "vscode": {
+      "extensions": [
+        "mongodb.mongodb-vscode"
+      ]
+    }
+  },
+  "portsAttributes": {
+    "5173": {
+      "label": "Server",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "forwardPorts": [
+    5173 
+  ],
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+}


### PR DESCRIPTION
- added a `.devcontainer` file to run Mongo Modeler:
	- locally using Docker and Visual Studio Code
	- in a GitHub Codespace, directly in the browser
- just create a Codespace and wait. The editor and a preview window will open with Mongo Modeler in it
- this also adds the MongoDB Visual Studio Code extension

<img width="2652" height="1507" alt="mongo-modeler" src="https://github.com/user-attachments/assets/9bf03d12-a675-42dc-b702-5cd9458e3356" />
