### PR TITLE
Feature/#580 if dirty confirmation dialog new model

### DIFF
--- a/src/common/components/modal-dialog/modal-dialog.component.tsx
+++ b/src/common/components/modal-dialog/modal-dialog.component.tsx
@@ -53,7 +53,7 @@ export const ModalDialog: React.FC = () => {
           transition={{ duration: 0.4 }}
         >
           <motion.div
-            className={styles.dialog}
+            className={`${styles.dialog} ${modalDialog.compact ? styles.dialogCompact : ''}`}
             role="dialog"
             initial={{ opacity: 0, scale: 0.8 }}
             animate={{ opacity: 1, scale: 1 }}

--- a/src/common/components/modal-dialog/modal-dialog.const.ts
+++ b/src/common/components/modal-dialog/modal-dialog.const.ts
@@ -8,3 +8,4 @@ export const EDIT_NOTE_TITLE = 'Edit Note';
 export const ABOUT_TITLE = 'About us';
 export const EXPORT_MODEL_TITLE = 'Export Model';
 export const IMPORT_COLLECTION_TITLE = 'Import JSON Document';
+export const NEW_MODEL_CONFIRMATION_TITLE = 'New Model';

--- a/src/common/components/modal-dialog/modal-dialog.styles.module.css
+++ b/src/common/components/modal-dialog/modal-dialog.styles.module.css
@@ -23,6 +23,11 @@
   border-radius: var(--border-radius-m);
 }
 
+.dialogCompact {
+  height: auto;
+  max-height: 90vh;
+}
+
 .dialog-header {
   position: sticky;
   top: 0;

--- a/src/core/providers/modal-dialog-provider/modal-dialog.model.ts
+++ b/src/core/providers/modal-dialog-provider/modal-dialog.model.ts
@@ -4,16 +4,18 @@ export interface ModalDialogModel {
   isOpen: boolean;
   selectedComponent: React.ReactNode | null;
   title: string;
+  compact?: boolean;
 }
 
 export const createInitialModalDialog = (): ModalDialogModel => ({
   isOpen: false,
   selectedComponent: null,
   title: '',
+  compact: false,
 });
 
 export interface ModalDialogContextModel {
-  openModal: (component: React.ReactNode | null, title: string) => void;
+  openModal: (component: React.ReactNode | null, title: string, compact?: boolean) => void;
   closeModal: () => void;
   modalDialog: ModalDialogModel;
 }

--- a/src/core/providers/modal-dialog-provider/modal-dialog.provider.tsx
+++ b/src/core/providers/modal-dialog-provider/modal-dialog.provider.tsx
@@ -15,11 +15,12 @@ export const ModalDialogProvider: React.FC<Props> = props => {
     createInitialModalDialog()
   );
 
-  const openModal = (component: React.ReactNode | null, title: string) => {
+  const openModal = (component: React.ReactNode | null, title: string, compact?: boolean) => {
     setModalDialog({
       isOpen: true,
       selectedComponent: component,
       title,
+      compact,
     });
   };
 

--- a/src/pods/toolbar/components/new-button/new-button.component.tsx
+++ b/src/pods/toolbar/components/new-button/new-button.component.tsx
@@ -25,7 +25,8 @@ export const NewButton = () => {
     if (!canvasSchema.isPristine) {
       openModal(
         <NewModelDialog onConfirm={doCreateNew} onCancel={closeModal}/>,
-        NEW_MODEL_CONFIRMATION_TITLE
+        NEW_MODEL_CONFIRMATION_TITLE,
+        true
       )
     } else {
       doCreateNew();

--- a/src/pods/toolbar/components/new-button/new-button.component.tsx
+++ b/src/pods/toolbar/components/new-button/new-button.component.tsx
@@ -5,16 +5,32 @@ import {
 } from '@/core/providers';
 import { ActionButton } from '@/common/components/action-button';
 import { SHORTCUTS } from '@/common/shortcut';
+import { useModalDialogContext } from '@/core/providers';
+import { NEW_MODEL_CONFIRMATION_TITLE } from '@/common/components';
+import { NewModelDialog } from './new-model-dialog.component';
 
 export const NewButton = () => {
-  const { createEmptySchema } = useCanvasSchemaContext();
+  const { canvasSchema, createEmptySchema } = useCanvasSchemaContext();
   const { setFilename, setLoadSample } = useCanvasViewSettingsContext();
+  const { openModal, closeModal } = useModalDialogContext();
 
-  const handleNewButtonClick = () => {
+  const doCreateNew = () => {
     setFilename('');
     createEmptySchema();
     setLoadSample(false);
+    closeModal();
   };
+
+  const handleNewButtonClick = () => {
+    if (!canvasSchema.isPristine) {
+      openModal(
+        <NewModelDialog onConfirm={doCreateNew} onCancel={closeModal}/>,
+        NEW_MODEL_CONFIRMATION_TITLE
+      )
+    } else {
+      doCreateNew();
+    }
+  }
 
   return (
     <ActionButton

--- a/src/pods/toolbar/components/new-button/new-model-dialog.component.tsx
+++ b/src/pods/toolbar/components/new-button/new-model-dialog.component.tsx
@@ -6,9 +6,17 @@ interface Props {
 export const NewModelDialog = ({ onConfirm, onCancel }: Props) => (
   <div role="alertdialog" aria-modal="true">
     <p>You have unsaved changes. Are you sure you want to create a new model? All current progress will be lost.</p>
-    <div>
-      <button onClick={onCancel}>Cancel</button>
-      <button onClick={onConfirm}>Confirm</button>
+    <div className="two-buttons" >
+        <button
+            className="button-secondary"
+            onClick={onCancel}>
+            Cancel
+        </button>
+        <button
+            className="button-tertiary"
+            onClick={onConfirm}>
+            Confirm
+        </button>
     </div>
   </div>
 );

--- a/src/pods/toolbar/components/new-button/new-model-dialog.component.tsx
+++ b/src/pods/toolbar/components/new-button/new-model-dialog.component.tsx
@@ -1,3 +1,5 @@
+import classes from './new-model.module.css'
+
 interface Props {
     onConfirm: () => void;
     onCancel: () => void;
@@ -5,17 +7,17 @@ interface Props {
 
 export const NewModelDialog = ({ onConfirm, onCancel }: Props) => (
   <div role="alertdialog" aria-modal="true">
-    <p>You have unsaved changes. Are you sure you want to create a new model? All current progress will be lost.</p>
+    <p className={classes.menssage}>You have unsaved changes. Are you sure you want to create a new model? All current progress will be lost.</p>
     <div className="two-buttons" >
         <button
             className="button-secondary"
-            onClick={onCancel}>
-            Cancel
+            onClick={onConfirm}>
+            Confirm
         </button>
         <button
             className="button-tertiary"
-            onClick={onConfirm}>
-            Confirm
+            onClick={onCancel}>
+            Cancel
         </button>
     </div>
   </div>

--- a/src/pods/toolbar/components/new-button/new-model-dialog.component.tsx
+++ b/src/pods/toolbar/components/new-button/new-model-dialog.component.tsx
@@ -1,0 +1,14 @@
+interface Props {
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+export const NewModelDialog = ({ onConfirm, onCancel }: Props) => (
+  <div role="alertdialog" aria-modal="true">
+    <p>You have unsaved changes. Are you sure you want to create a new model? All current progress will be lost.</p>
+    <div>
+      <button onClick={onCancel}>Cancel</button>
+      <button onClick={onConfirm}>Confirm</button>
+    </div>
+  </div>
+);

--- a/src/pods/toolbar/components/new-button/new-model.module.css
+++ b/src/pods/toolbar/components/new-button/new-model.module.css
@@ -1,0 +1,6 @@
+.menssage {
+    font-size: var(--fs-m);
+    color: var(--text-color);
+    text-align: center;
+    margin: 0 0 var(--space-md);
+}


### PR DESCRIPTION
This PR adds a modal confirmation dialog; if the user clicks the New button and the model has been modified (the schema is not Pristine), it shows the modal dialog.

<img width="1784" height="870" alt="confirm-dialog-new" src="https://github.com/user-attachments/assets/737792f3-4a79-4c06-a2e1-f49ba0e346fd" />

Resolves: #580 
